### PR TITLE
Fix adding Faxes

### DIFF
--- a/app/fax/fax_edit.php
+++ b/app/fax/fax_edit.php
@@ -283,7 +283,7 @@
 			if ($_POST["persistformvar"] != "true") {
 
 				//prep authorized senders
-					if (sizeof($fax_email_outbound_authorized_senders) > 0) {
+					if (is_array($fax_email_outbound_authorized_senders) && (sizeof($fax_email_outbound_authorized_senders) > 0)) {
 						foreach ($fax_email_outbound_authorized_senders as $sender_num => $sender) {
 							if ($sender == '' || (substr_count($sender, '@') == 1 && !valid_email($sender)) || substr_count($sender, '.') == 0) {
 								unset($fax_email_outbound_authorized_senders[$sender_num]);


### PR DESCRIPTION
$fax_email_outbound_authorized_senders is only filled when fax_estension_advanced permission is set. However, the edit part doesn't verify that sizeof(NULL) creates a fatal error.

Fatal error: Uncaught TypeError: sizeof(): Argument #1 ($value) must be of type Countable|array, null given in /var/www/fusionpbx/app/fax/fax_edit.php:286 Stack trace: #0 {main} thrown in /var/www/fusionpbx/app/fax/fax_edit.php on line 286

This patch verifies that $fax_email_outbound_authorized_senders is an array before sizeof() evaluates it. You can now add faxes with the fax_estension_advanced disabled.